### PR TITLE
allow scrolling props.parent instead of on window only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-headroom",
   "description": "Hide your header until you need it. React.js port of headroom.js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/KyleAMathews/react-headroom/issues"

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -17,6 +17,7 @@ module.exports = React.createClass
   ticking: false
 
   propTypes:
+    parent: React.PropTypes.node
     children: PropTypes.any.isRequired
     disableInlineStyles: PropTypes.bool
     disable: PropTypes.bool
@@ -28,6 +29,7 @@ module.exports = React.createClass
     wrapperStyle: PropTypes.object
 
   getDefaultProps: ->
+    parent: -> window
     disableInlineStyles: false
     disable: false
     upTolerance: 5
@@ -37,6 +39,7 @@ module.exports = React.createClass
     onUnfix: ->
     wrapperStyle: {}
 
+
   getInitialState: ->
     state: 'unfixed'
     translateY: 0
@@ -45,22 +48,25 @@ module.exports = React.createClass
   componentDidMount: ->
     @setState height: @refs.inner.getDOMNode().offsetHeight
     unless @props.disable
-      window.addEventListener('scroll', @handleScroll)
+      @props.parent().addEventListener('scroll', @handleScroll)
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.disable and not @props.disable
       @unfix()
 
       # Remove the event listener
-      window.removeEventListener('scroll', @handleScroll)
+      @props.parent().removeEventListener('scroll', @handleScroll)
 
     else if not nextProps.disable and @props.disable
-      window.addEventListener('scroll', @handleScroll)
+      @props.parent().addEventListener('scroll', @handleScroll)
 
   componentDidUpdate: (prevProps, prevState) ->
     # If children have changed, remeasure height.
     if prevProps.children isnt @props.children
       @setState height: @refs.inner.getDOMNode().offsetHeight
+
+  componentWillUnmount: ->
+    @props.parent().removeEventListener('scroll', @handleScroll)
 
   handleScroll: ->
     unless @ticking
@@ -112,10 +118,10 @@ module.exports = React.createClass
     @ticking = false
 
   getScrollY: ->
-    if window.pageYOffset != undefined
-      window.pageYOffset
-    else if window.scrollTop != undefined
-      window.scrollTop
+    if @props.parent().pageYOffset != undefined
+      @props.parent().pageYOffset
+    else if @props.parent().scrollTop != undefined
+      @props.parent().scrollTop
     else (document.documentElement or
       document.body.parentNode or
       document.body).scrollTop


### PR DESCRIPTION
usefull for https://github.com/seatgeek/react-infinite/
related to https://github.com/seatgeek/react-infinite/pull/47