### PR TITLE
Add pinStart prop

### DIFF
--- a/examples/examples.cjsx
+++ b/examples/examples.cjsx
@@ -111,6 +111,7 @@ module.exports = React.createClass
             <li><code>disable</code> — disable pinning and unpinning</li>
             <li><code>wrapperStyle</code> — pass styles to be added to the wrapper div (this maintains the components vertical space at the top of the page).</li>
             <li><code>parent</code> — provide a custom "parent" element for scroll events. <code>parent</code> should be a function which resolves to the desired element.</li>
+            <li><code>pinStart</code> — height in px where the header should start and stop pinning. Useful when you have another element above Headroom component.</li>
           </ul>
         </div>
       </Container>

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -26,7 +26,8 @@ module.exports = React.createClass
     onPin: PropTypes.func
     onUnpin: PropTypes.func
     onUnfix: PropTypes.func
-    wrapperStyle: PropTypes.object
+    wrapperStyle: PropTypes.object,
+    pinStart: PropTypes.number
 
   getDefaultProps: ->
     parent: -> window
@@ -38,6 +39,7 @@ module.exports = React.createClass
     onUnpin: ->
     onUnfix: ->
     wrapperStyle: {}
+    pinStart: 0
 
 
   getInitialState: ->

--- a/src/shouldUpdate.coffee
+++ b/src/shouldUpdate.coffee
@@ -3,7 +3,7 @@ module.exports = (lastKnownScrollY=0, currentScrollY=0, props={}, state={}) ->
   distanceScrolled = Math.abs(currentScrollY - lastKnownScrollY)
 
   # We're at the top and not fixed yet.
-  if currentScrollY < 0 and
+  if currentScrollY < props.pinStart and
       state.state isnt "unfixed"
     return {
       action: "unfix"
@@ -23,7 +23,7 @@ module.exports = (lastKnownScrollY=0, currentScrollY=0, props={}, state={}) ->
   # We transition to "unpinned" if necessary.
   else if scrollDirection is "down" and
       state.state in ["pinned", "unfixed"] and
-      currentScrollY > state.height and
+      currentScrollY > (state.height + props.pinStart) and
       distanceScrolled > props.downTolerance
     return {
       action: "unpin"

--- a/test/calc.coffee
+++ b/test/calc.coffee
@@ -54,6 +54,15 @@ describe 'shouldUpdate', ->
     result = shouldUpdate(0, 10, propDefaults, state)
     expect(result.action).to.equal('unpin')
 
+  it 'should not return an action of "unpin" if scrolling down and unfixed
+      but the scrolling amount is less than pinStart', ->
+    propDefaults.pinStart = 200
+    state =
+      height: 0
+      state: "unfixed"
+    result = shouldUpdate(100, 110, propDefaults, state)
+    expect(result.action).to.equal('none')
+
   it 'should not return an action of "unpin" if scrolling down and pinned
       but the scrolling amount is less than downTolerance', ->
     propDefaults.downTolerance = 1000
@@ -128,14 +137,24 @@ describe 'shouldUpdate', ->
     expect(result.action).to.equal('none')
 
   it "should return an action of 'unfix' if
-      currentScroll is less than 0", ->
-
+      currentScroll is less than pinStart", ->
+    propDefaults.pinStart = 20
     state =
       height: 100
       state: "pinned"
-    result = shouldUpdate(100, -100, propDefaults, state)
+    result = shouldUpdate(100, 10, propDefaults, state)
 
     expect(result.action).to.equal('unfix')
+
+  it "should not return an action of 'unfix' if
+      currentScroll is more than pinStart", ->
+    propDefaults.pinStart = 20
+    state =
+      height: 100
+      state: "pinned"
+    result = shouldUpdate(100, 50, propDefaults, state)
+
+    expect(result.action).to.equal('none')
 
   it "should return an action of 'unpin' if scroll down past height
       of header", ->

--- a/test/calc.coffee
+++ b/test/calc.coffee
@@ -4,14 +4,18 @@ _ = require 'underscore'
 
 shouldUpdate = require '../src/shouldUpdate'
 
-propDefaults =
-  disableInlineStyles: false
-  disable: false
-  upTolerance: 0
-  downTolerance: 0
-  offset: 0
+propDefaults = {}
 
 describe 'shouldUpdate', ->
+  beforeEach ->
+    propDefaults =
+      disableInlineStyles: false
+      disable: false
+      upTolerance: 0
+      downTolerance: 0
+      offset: 0
+      pinStart: 0
+
   it 'should exist', ->
     expect(shouldUpdate).to.exist
 
@@ -59,9 +63,6 @@ describe 'shouldUpdate', ->
     result = shouldUpdate(100, 110, propDefaults, state)
     expect(result.action).to.equal('none')
 
-    # Restore default
-    propDefaults.downTolerance = 0
-
   it 'should return an action of "pin" if scrolling up and unpinned', ->
     state =
       height: 0
@@ -77,9 +78,6 @@ describe 'shouldUpdate', ->
       state: "unpinned"
     result = shouldUpdate(110, 100, propDefaults, state)
     expect(result.action).to.equal('none')
-
-    # Restore default
-    propDefaults.upTolerance = 0
 
   it "should return an action of 'none' if haven't scrolled
       past height of header", ->
@@ -105,15 +103,12 @@ describe 'shouldUpdate', ->
       state: "unpinned"
     result = shouldUpdate(50, 10, propDefaults, state)
     expect(result.action).to.equal('pin')
-    
+
     state =
       height: 100
       state: "unpinned"
     result = shouldUpdate(50, 0, propDefaults, state)
     expect(result.action).to.equal('pin')
-
-    # Restore default
-    propDefaults.upTolerance = 0
 
   it "should return an action of 'none' if scrolling down when pinned within
       height of header", ->
@@ -122,7 +117,7 @@ describe 'shouldUpdate', ->
       state: "pinned"
     result = shouldUpdate(50, 80, propDefaults, state)
     expect(result.action).to.equal('none')
-    
+
   it "should return an action of 'none' if scrolling up when pinned within
       height of header or at the top", ->
     state =
@@ -134,7 +129,7 @@ describe 'shouldUpdate', ->
 
   it "should return an action of 'unfix' if
       currentScroll is less than 0", ->
-    
+
     state =
       height: 100
       state: "pinned"


### PR DESCRIPTION
I've added a new prop called `pinStart`.When set, Headroom doesn't start pinning until you scroll the first `pinStart` pixels of the page. It can be used when you have another element above Headroom component.

You can test it in the examples page making these changes:

```
@@ -5,10 +5,12 @@ Headroom = require '../src/index'
 module.exports = React.createClass
   render: ->
     <div style={{marginBottom: 64}}>
+      <div style={{height: '60px'}}>header</div>
       <Headroom
         onPin={-> console.log "pinned"}
         onUnpin={-> console.log "unpinned"}
         wrapperStyle={marginBottom: '3rem'}
+        pinStart=60
         style={{
```