### PR TITLE
Use object-assign instead of deprecated React's polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "raf": "^3.1.0",
+    "object-assign": "^4.0.1",
     "react-addons-pure-render-mixin": "^0.14.3"
   },
   "devDependencies": {

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-objectAssign = require('react/lib/Object.assign')
+objectAssign = require('object-assign')
 PureRenderMixin = require('react-addons-pure-render-mixin')
 raf = require 'raf'
 PropTypes = React.PropTypes


### PR DESCRIPTION
For what I understand with React 15.0 the core team removed their internal polyfill of `Object.assign` for an updated one ([here's the issue](https://github.com/facebook/react/pull/6376)).

This PR should make react-headroom compatibile with React 15.0.