### PR TITLE
Change initial state class to 'headroom headroom--unfixed'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default class Headroom extends Component {
     this.state = {
       state: 'unfixed',
       translateY: 0,
-      className: 'headroom headroom--pinned',
+      className: 'headroom headroom--unfixed',
     }
 
     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this)


### PR DESCRIPTION
This causes the initial class name to be correctly set to `headroom--unfixed`.
Its needed mainly for when  `pinStart` is greater than 0.

fixes #45 