### PR TITLE
Relax react-addons-pure-render-mixin requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "raf": "^3.2.0",
-    "react-addons-pure-render-mixin": "^15.0.2"
+    "react-addons-pure-render-mixin": "^0.14||^15.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
I have a project that isn't able to upgrade to React 15 yet. Headroom functions with v0.14, but it's impossible to `npm shrinkwrap`.

```
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: react@^15.0.2, required by react-addons-pure-render-mixin@15.0.2
```
