### PR TITLE
add classname for transition state

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-1", "react"]
+  "presets": ["es2015", "stage-1", "react"],
+  "plugins": ["transform-undefined-to-void"]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.3",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-undefined-to-void": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-jsx-a11y": "^1.0.4",
+    "eslint-plugin-react": "^5.1.1",
     "mocha": "^2.4.5",
     "mocha-unfunk-reporter": "^0.4.0",
     "pre-commit": "^1.0.5"

--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,8 @@ export default class Headroom extends Component {
       transform: `translateY(${this.state.translateY})`,
     }
 
+    let className = this.state.className
+
     // Don't add css transitions until after we've done the initial
     // negative transform when transitioning from 'unfixed' to 'unpinned'.
     // If we don't do this, the header will flash into view temporarily
@@ -177,6 +179,7 @@ export default class Headroom extends Component {
         OTransition: 'all .2s ease-in-out',
         transition: 'all .2s ease-in-out',
       }
+      className += ' headroom--scrolled'
     }
 
     if (!this.props.disableInlineStyles) {
@@ -199,7 +202,7 @@ export default class Headroom extends Component {
           ref="inner"
           {...this.props}
           style={style}
-          className={this.state.className}
+          className={className}
         >
           {this.props.children}
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -83,9 +83,9 @@ export default class Headroom extends Component {
   }
 
   getScrollY = () => {
-    if (this.props.parent().pageYOffset !== void 0) {
+    if (this.props.parent().pageYOffset !== undefined) {
       return this.props.parent().pageYOffset
-    } else if (this.props.parent().scrollTop !== void 0) {
+    } else if (this.props.parent().scrollTop !== undefined) {
       return this.props.parent().scrollTop
     } else {
       return (document.documentElement || document.body.parentNode || document.body).scrollTop
@@ -193,7 +193,7 @@ export default class Headroom extends Component {
 
     const wrapperStyles = {
       ...this.props.wrapperStyle,
-      height: this.state.height ? this.state.height : void 0,
+      height: this.state.height ? this.state.height : null,
     }
 
     return (

--- a/website/pages/index.md
+++ b/website/pages/index.md
@@ -43,18 +43,25 @@ Another option is to use css. The component has a `headroom` class as well as a 
 
 ```javascript
 .headroom {
-  transition: transform 200ms linear;
-  position: fixed;
+  top: 0;
   left: 0;
   right: 0;
-  top: 0;
   zIndex: 1;
 }
-.headroom--pinned {
-  transform: translateY(0%);
+.headroom--unfixed {
+  position: relative;
+  transform: translateY(0);
+}
+.headroom--scrolled {
+  transition: transform 200ms ease-in-out;
 }
 .headroom--unpinned {
+  position: fixed;
   transform: translateY(-100%);
+}
+.headroom--pinned {
+  position: fixed;
+  transform: translateY(0%);
 }
 ```
 


### PR DESCRIPTION
The current version of the component unfortunately doesn't provide a full coverage for only using the CSS names instead of inline styles. So far the [deferred attachment of the transition after the initial scroll](https://github.com/KyleAMathews/react-headroom/blob/master/src/index.js#L172) is missing. With this update the `headroom--scrolled` classname is added and referenced in the docs.

In addition I've added the missing `eslint-plugin` for the react rules and included a `babel-plugin` which transforms `undefined` into `void` as its often easier to understand for other developers.