### PR TITLE
Add prop-types package; remove deprecated reference to React.PropTypes (v15.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "prop-types": "*"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react' // eslint-disable-line import/no-unresolved
+import React, { Component } from 'react' // eslint-disable-line import/no-unresolved
+import PropTypes from 'prop-types'
 import shallowequal from 'shallowequal'
 import raf from 'raf'
 import shouldUpdate from './shouldUpdate'


### PR DESCRIPTION
This change introduces the new method for accessing PropTypes. As of React 15.5, React.PropTypes is deprecated and has been extracted into a separate package (`prop-types`).