### PR TITLE
Allow user to pass className to headroom wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const noop = () => {}
 
 export default class Headroom extends Component {
   static propTypes = {
+    className: PropTypes.string,
     parent: PropTypes.func,
     children: PropTypes.any.isRequired,
     disableInlineStyles: PropTypes.bool,
@@ -219,7 +220,7 @@ export default class Headroom extends Component {
   }
 
   render () {
-    const { ...divProps } = this.props
+    const { className: userClassName, ...divProps } = this.props
     delete divProps.onUnpin
     delete divProps.onPin
     delete divProps.onUnfix
@@ -275,8 +276,12 @@ export default class Headroom extends Component {
       height: this.state.height ? this.state.height : null,
     }
 
+    const wrapperClassName = userClassName
+      ? `${userClassName} headroom-wrapper`
+      : 'headroom-wrapper'
+
     return (
-      <div style={wrapperStyles} className="headroom-wrapper">
+      <div style={wrapperStyles} className={wrapperClassName}>
         <div
           ref="inner"
           {...rest}


### PR DESCRIPTION
Hi, thanks for the package, it works great, but I have a minor issue. When trying to use the fix advised in #36 to use react-headroom for a footer, I need to overwrite the `.headroom` classNames. However, I use a CSS in JS lib ([fela](https://github.com/rofrischmann/fela)) on my project, and I have to pass the className directly to your component, that doesn't allow it :/

This PR fixes that by concatenating any eventual className passed by the user to the wrapper.