### PR TITLE
Add option to recalculate height on resize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
+  - "8"


### PR DESCRIPTION
This commit introduces a new prop: `calcHeightOnResize`. When this prop
has the value `true`, the Headroom component will add a resize listener
and recalculate the height of the wrapping div on resize.

Fixes https://github.com/KyleAMathews/react-headroom/issues/100