### PR TITLE
fix: prevent www/ directory from publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,4 @@ node_modules
 .lock-wscript
 susy-test/
 examples/bundle.js
+www


### PR DESCRIPTION
The current version of react-headroom (2.2.1) has this folder in its structure and should not be installed through npm :
The purpose of this directory is to provide a demo, so I guess nobody will run it through their node_modules/ directory.