### PR TITLE
Support custom class names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,17 @@ import shouldUpdate from './shouldUpdate'
 
 const noop = () => {}
 
+const defaultClasses = {
+  main: 'headroom',
+  unfixed: 'headroom--unfixed',
+  scrolled: 'headroom--scrolled',
+  unpinned: 'headroom--unpinned',
+  pinned: 'headroom--pinned',
+}
+
 export default class Headroom extends Component {
   static propTypes = {
+    classes: PropTypes.object,
     className: PropTypes.string,
     parent: PropTypes.func,
     children: PropTypes.any.isRequired,
@@ -45,10 +54,11 @@ export default class Headroom extends Component {
     this.lastKnownScrollY = 0
     this.scrollTicking = false
     this.resizeTicking = false
+    this.classes = Object.assign({}, defaultClasses, props.classes)
     this.state = {
       state: 'unfixed',
       translateY: 0,
-      className: 'headroom headroom--unfixed',
+      className: `${this.classes.main} ${this.classes.unfixed}`,
     }
   }
 
@@ -75,6 +85,7 @@ export default class Headroom extends Component {
         this.props.parent().addEventListener('resize', this.handleResize)
       }
     }
+    this.classes = Object.assign({}, defaultClasses, nextProps.classes)
   }
 
   shouldComponentUpdate (nextProps, nextState) {
@@ -190,7 +201,7 @@ export default class Headroom extends Component {
 
     this.setState({
       translateY: '-100%',
-      className: 'headroom headroom--unpinned',
+      className: `${this.classes.main} ${this.classes.unpinned}`,
     }, () => {
       setTimeout(() => {
         this.setState({ state: 'unpinned' })
@@ -203,7 +214,7 @@ export default class Headroom extends Component {
 
     this.setState({
       translateY: 0,
-      className: 'headroom headroom--pinned',
+      className: `${this.classes.main} ${this.classes.pinned}`,
       state: 'pinned',
     })
   }
@@ -213,7 +224,7 @@ export default class Headroom extends Component {
 
     this.setState({
       translateY: 0,
-      className: 'headroom headroom--unfixed',
+      className: `${this.classes.main} ${this.classes.unfixed}`,
       state: 'unfixed',
     })
   }
@@ -255,6 +266,7 @@ export default class Headroom extends Component {
     delete divProps.downTolerance
     delete divProps.pinStart
     delete divProps.calcHeightOnResize
+    delete divProps.classes
 
     const { style, wrapperStyle, ...rest } = divProps
 

--- a/www/pages/index.md
+++ b/www/pages/index.md
@@ -1,8 +1,13 @@
 [Code on Github](https://github.com/KyleAMathews/react-headroom)
 
-React Headroom is a React Component to hide/show your header on scroll. The header on this site is a living example. When you scroll down, it slides out of view and slides back in when scrolling up.
+React Headroom is a React Component to hide/show your header on scroll. The
+header on this site is a living example. When you scroll down, it slides out of
+view and slides back in when scrolling up.
 
-Fixed headers are nice for persistent navigation but they can also get in the way by taking up valuable vertical screen space. Using this component lets you have your persistent navigation while preserving screen space when the navigation is not needed.
+Fixed headers are nice for persistent navigation but they can also get in the
+way by taking up valuable vertical screen space. Using this component lets you
+have your persistent navigation while preserving screen space when the
+navigation is not needed.
 
 ## Install
 
@@ -17,16 +22,19 @@ Here's an example:
 ```javascript
 <Headroom>
   <h1>You can put anything you'd like inside the Headroom Component</h1>
-</Headroom>
+</Headroom>;
 ```
 
 [See the code for this website.](https://github.com/KyleAMathews/react-headroom/blob/master/www/page-templates/index.js)
 
 ### Overriding animation
 
-The component is intended to be plug 'n play meaning it has sensible defaults for animating the header in and out. If you'd like to override the default animation, you have two options.
+The component is intended to be plug 'n play meaning it has sensible defaults
+for animating the header in and out. If you'd like to override the default
+animation, you have two options.
 
-One option is you can override the default inline styles like the following example:
+One option is you can override the default inline styles like the following
+example:
 
 ```javascript
 <Headroom style={{
@@ -39,7 +47,10 @@ One option is you can override the default inline styles like the following exam
 </Headroom>
 ```
 
-Another option is to use CSS. The component has a `headroom` class as well as a `headroom--pinned` or `headroom--unpinned` depending on its pinned state. As CSS can't override inline styles, first disable the animation styles by passing in the `disableInlineStyles` prop. Then in your CSS do something like:
+Another option is to use CSS. The component has a `headroom` class as well as a
+`headroom--pinned` or `headroom--unpinned` depending on its pinned state. As CSS
+can't override inline styles, first disable the animation styles by passing in
+the `disableInlineStyles` prop. Then in your CSS do something like:
 
 ```javascript
 .headroom {
@@ -65,14 +76,42 @@ Another option is to use CSS. The component has a `headroom` class as well as a 
 }
 ```
 
+#### Specifying custom class names
+
+This component can be used with CSS-in-JS styling solutions like
+[JSS](https://github.com/cssinjs/jss) that specify their own class names by
+passing the `classes` property.
+
+```javascript
+<Headroom
+  disableInlineStyles
+  classes={{
+    main: classes.headroom,
+    unfixed: classes.headroomUnfixed,
+    scrolled: classes.headroomScrolled,
+    pinned: classes.headroomPinned,
+    unpinned: classes.headroomUnpinned
+  }}
+>
+  <h1>This headroom uses custom CSS classes</h1>
+</Headroom>
+```
+
+This way, you can also use multiple headroom components with different stylings on one page.
+
 ### Other props
 
-*   `onPin` — callback called when header is pinned
-*   `onUnpin` — callback called when header is unpinned
-*   `onUnfix` — callback called when header position is no longer fixed
-*   `upTolerance` — scroll tolerance in px when scrolling up before component is pinned
-*   `downTolerance` — scroll tolerance in px when scrolling down before component is pinned
-*   `disable` — disable pinning and unpinning
-*   `wrapperStyle` — pass styles for the wrapper div (this maintains the components vertical space at the top of the page).
-*   `parent` — provide a custom 'parent' element for scroll events. `parent` should be a function which resolves to the desired element.
-*   `pinStart` — height in px where the header should start and stop pinning. Useful when you have another element above Headroom component.
+* `onPin` — callback called when header is pinned
+* `onUnpin` — callback called when header is unpinned
+* `onUnfix` — callback called when header position is no longer fixed
+* `upTolerance` — scroll tolerance in px when scrolling up before component is
+  pinned
+* `downTolerance` — scroll tolerance in px when scrolling down before component
+  is pinned
+* `disable` — disable pinning and unpinning
+* `wrapperStyle` — pass styles for the wrapper div (this maintains the
+  components vertical space at the top of the page).
+* `parent` — provide a custom 'parent' element for scroll events. `parent`
+  should be a function which resolves to the desired element.
+* `pinStart` — height in px where the header should start and stop pinning.
+  Useful when you have another element above Headroom component.

--- a/www/pages/index.md
+++ b/www/pages/index.md
@@ -1,13 +1,8 @@
 [Code on Github](https://github.com/KyleAMathews/react-headroom)
 
-React Headroom is a React Component to hide/show your header on scroll. The
-header on this site is a living example. When you scroll down, it slides out of
-view and slides back in when scrolling up.
+React Headroom is a React Component to hide/show your header on scroll. The header on this site is a living example. When you scroll down, it slides out of view and slides back in when scrolling up.
 
-Fixed headers are nice for persistent navigation but they can also get in the
-way by taking up valuable vertical screen space. Using this component lets you
-have your persistent navigation while preserving screen space when the
-navigation is not needed.
+Fixed headers are nice for persistent navigation but they can also get in the way by taking up valuable vertical screen space. Using this component lets you have your persistent navigation while preserving screen space when the navigation is not needed.
 
 ## Install
 
@@ -22,19 +17,16 @@ Here's an example:
 ```javascript
 <Headroom>
   <h1>You can put anything you'd like inside the Headroom Component</h1>
-</Headroom>;
+</Headroom>
 ```
 
 [See the code for this website.](https://github.com/KyleAMathews/react-headroom/blob/master/www/page-templates/index.js)
 
 ### Overriding animation
 
-The component is intended to be plug 'n play meaning it has sensible defaults
-for animating the header in and out. If you'd like to override the default
-animation, you have two options.
+The component is intended to be plug 'n play meaning it has sensible defaults for animating the header in and out. If you'd like to override the default animation, you have two options.
 
-One option is you can override the default inline styles like the following
-example:
+One option is you can override the default inline styles like the following example:
 
 ```javascript
 <Headroom style={{
@@ -47,10 +39,7 @@ example:
 </Headroom>
 ```
 
-Another option is to use CSS. The component has a `headroom` class as well as a
-`headroom--pinned` or `headroom--unpinned` depending on its pinned state. As CSS
-can't override inline styles, first disable the animation styles by passing in
-the `disableInlineStyles` prop. Then in your CSS do something like:
+Another option is to use CSS. The component has a `headroom` class as well as a `headroom--pinned` or `headroom--unpinned` depending on its pinned state. As CSS can't override inline styles, first disable the animation styles by passing in the `disableInlineStyles` prop. Then in your CSS do something like:
 
 ```javascript
 .headroom {
@@ -101,17 +90,12 @@ This way, you can also use multiple headroom components with different stylings 
 
 ### Other props
 
-* `onPin` — callback called when header is pinned
-* `onUnpin` — callback called when header is unpinned
-* `onUnfix` — callback called when header position is no longer fixed
-* `upTolerance` — scroll tolerance in px when scrolling up before component is
-  pinned
-* `downTolerance` — scroll tolerance in px when scrolling down before component
-  is pinned
-* `disable` — disable pinning and unpinning
-* `wrapperStyle` — pass styles for the wrapper div (this maintains the
-  components vertical space at the top of the page).
-* `parent` — provide a custom 'parent' element for scroll events. `parent`
-  should be a function which resolves to the desired element.
-* `pinStart` — height in px where the header should start and stop pinning.
-  Useful when you have another element above Headroom component.
+*   `onPin` — callback called when header is pinned
+*   `onUnpin` — callback called when header is unpinned
+*   `onUnfix` — callback called when header position is no longer fixed
+*   `upTolerance` — scroll tolerance in px when scrolling up before component is pinned
+*   `downTolerance` — scroll tolerance in px when scrolling down before component is pinned
+*   `disable` — disable pinning and unpinning
+*   `wrapperStyle` — pass styles for the wrapper div (this maintains the components vertical space at the top of the page).
+*   `parent` — provide a custom 'parent' element for scroll events. `parent` should be a function which resolves to the desired element.
+*   `pinStart` — height in px where the header should start and stop pinning. Useful when you have another element above Headroom component.


### PR DESCRIPTION
Added support for a `classes` prop with custom class names, to be used with JSS or other CSS-in-JS solutions.

I might have overlooked an easier way, but this lets me use react-headroom with JSS.