### PR TITLE
bump shallowequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "prop-types": "^15.5.8",
     "raf": "^3.3.0",
-    "shallowequal": "^0.2.2"
+    "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Since version 0.2.2 shallowequal size went from 3.4kB to 561B. 
Also fixes #148 