### PR TITLE
Avoid flash of animation when scrolling from top

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -191,6 +191,18 @@ export default class Headroom extends Component {
     this.setState({
       translateY: '-100%',
       className: 'headroom headroom--unpinned',
+      animation: true,
+      state: 'unpinned',
+    })
+  }
+
+  unpinSnap = () => {
+    this.props.onUnpin()
+
+    this.setState({
+      translateY: '-100%',
+      className: 'headroom headroom--unpinned headroom-disable-animation',
+      animation: false,
       state: 'unpinned',
     })
   }
@@ -201,6 +213,7 @@ export default class Headroom extends Component {
     this.setState({
       translateY: 0,
       className: 'headroom headroom--pinned',
+      animation: true,
       state: 'pinned',
     })
   }
@@ -210,7 +223,8 @@ export default class Headroom extends Component {
 
     this.setState({
       translateY: 0,
-      className: 'headroom headroom--unfixed',
+      className: 'headroom headroom--unfixed headroom-disable-animation',
+      animation: false,
       state: 'unfixed',
     })
   }
@@ -230,6 +244,8 @@ export default class Headroom extends Component {
         this.pin()
       } else if (action === 'unpin') {
         this.unpin()
+      } else if (action === 'unpin-snap') {
+        this.unpinSnap()
       } else if (action === 'unfix') {
         this.unfix()
       }
@@ -272,7 +288,7 @@ export default class Headroom extends Component {
     // negative transform when transitioning from 'unfixed' to 'unpinned'.
     // If we don't do this, the header will flash into view temporarily
     // while it transitions from 0 — -100%.
-    if (this.state.state !== 'unfixed') {
+    if (this.state.animation) {
       innerStyle = {
         ...innerStyle,
         WebkitTransition: 'all .2s ease-in-out',

--- a/src/shouldUpdate.js
+++ b/src/shouldUpdate.js
@@ -32,6 +32,16 @@ export default function (
       scrollDirection,
       distanceScrolled,
     }
+  } else if (
+    currentScrollY > (state.height + props.pinStart) &&
+    scrollDirection === 'down' &&
+    state.state === 'unfixed'
+  ) {
+    return {
+      action: 'unpin-snap',
+      scrollDirection,
+      distanceScrolled,
+    }
   // We're past the header and scrolling down.
   // We transition to "unpinned" if necessary.
   } else if (

--- a/test/calc.js
+++ b/test/calc.js
@@ -194,6 +194,6 @@ describe('shouldUpdate', () => {
       state: 'unfixed',
     }
     const result = shouldUpdate(100, 110, propDefaults, state)
-    expect(result.action).to.equal('unpin')
+    expect(result.action).to.equal('unpin-snap')
   })
 })


### PR DESCRIPTION
A fix for issue #154 where the menu flashes in when scrolling past the height of the menu.

This is done by adding a boolean for animation in state, and adding an additional state in shouldUpdate that is triggered if you scroll past the height and pinstart and the state is unfixed.