### PR TITLE
Let consumers override wrapper inline `height` style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -324,8 +324,8 @@ export default class Headroom extends Component {
     }
 
     const wrapperStyles = {
-      ...wrapperStyle,
       height: this.state.height ? this.state.height : null,
+      ...wrapperStyle,
     }
 
     const wrapperClassName = userClassName


### PR DESCRIPTION
I'm currently using `<Headroom wrapperStyle={{ maxHeight: '0px' }}>` to hack around this. Essentially I want all the goodies of this component but without the default space reservation. I think it's reasonable to let consumers override this.