### PR TITLE
Check that parent exists when unmounting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,9 +107,11 @@ export default class Headroom extends Component {
   }
 
   componentWillUnmount () {
-    this.props.parent().removeEventListener('scroll', this.handleScroll)
+    if (this.props.parent()) {
+      this.props.parent().removeEventListener('scroll', this.handleScroll)
+      this.props.parent().removeEventListener('resize', this.handleResize)
+    }
     window.removeEventListener('scroll', this.handleScroll)
-    this.props.parent().removeEventListener('resize', this.handleResize)
   }
 
   setRef = ref => (this.inner = ref)


### PR DESCRIPTION
Prevents an error that occurs if the parent no longer exists on `componentWillUnmount`