### PR TITLE
Fix: Delay unfix state change to prevent Safari glitch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,10 @@ export default class Headroom extends Component {
       translateY: 0,
       className: 'headroom headroom--unfixed headroom-disable-animation',
       animation: false,
-      state: 'unfixed',
+    }, () => {
+      setTimeout(() => {
+        this.setState({ state: 'unfixed' })
+      }, 0)
     })
   }
 


### PR DESCRIPTION
## Problem

The header doesn't stay at the top of the page when scrolling to the top of the page quickly with Safari on MacOS.

## Related Issue

https://github.com/KyleAMathews/react-headroom/issues/185

## Proposed Change

Delay `unfixed` state change with `setTimeout()`.

## New Behaviour

Glitches are not happening anymore, although the header still disappears for a few milliseconds when scrolling to the top quickly.
